### PR TITLE
Do not coerce null and undefined to strings

### DIFF
--- a/source/b8r.byPath.js
+++ b/source/b8r.byPath.js
@@ -291,7 +291,7 @@ function setByPath(obj, path, val) {
 }
 
 function matchTypes(value, oldValue) {
-  if (typeof value === typeof oldValue) {
+  if (value == null || oldValue == null || typeof value === typeof oldValue) {
     return value;
   } else if (typeof value === 'string' && typeof oldValue === 'number') {
     return parseFloat(value);


### PR DESCRIPTION
Resolves this bug:

```
<p data-bind="show_if(_null_)=show.mode">Undef</p>
<script>
b8r.set('show.mode', 'foo')
b8r.set('show.mode', null) // <p> should be shown here, but it's not
</script>
```

Cause was that `b8r.set(...)` coerced `null` to a string.