### PR TITLE
Allow id path keys that contain equal signs

### DIFF
--- a/source/b8r.byPath.js
+++ b/source/b8r.byPath.js
@@ -225,8 +225,8 @@ function getByPath(obj, path) {
       if (!found.length) {
         found = undefined;
       } else if (part.indexOf('=') > -1) {
-        const [key_path, key_value] = part.split('=');
-        found = byKeyPath(found, key_path, key_value);
+        const [key_path, ...tail] = part.split('=');
+        found = byKeyPath(found, key_path, tail.join('='));
       } else {
         j = parseInt(part, 10);
         found = found[j];

--- a/tests.html
+++ b/tests.html
@@ -107,6 +107,7 @@
 			list: [
 				{x: 10, y: 11},
 				{x: 12, y: 13},
+				{x: 'y=z'}
 			],
 			color: 'red',
 			type: 'range',
@@ -126,6 +127,8 @@
 		Test(() => getByPath(obj, 'sub.list[1]')).shouldBe(obj.sub.list[1]);
 		Test(() => getByPath(obj, 'list[1].x')).shouldBe(obj.list[1].x);
 		Test(() => getByPath(obj, 'nested_list[1][1]')).shouldBe(obj.nested_list[1][1]);
+		Test(() => getByPath(obj, 'list[x=12]')).shouldBe(obj.list[1])
+		Test(() => getByPath(obj, 'list[x=y=z]')).shouldBe(obj.list[2])
 		setByPath(obj, 'base', 42);
 		setByPath(obj, 'kettle.black', 11);
 		Test(() => getByPath(obj, 'base')).shouldBe(obj.base);


### PR DESCRIPTION
If you're using, say, an url as an id, you can end up with a key that contains equals signs, making parse fail