### PR TITLE
Carousel change should be no-op for null elements

### DIFF
--- a/components/carousel.component.html
+++ b/components/carousel.component.html
@@ -191,6 +191,11 @@ Copyright ©2016-2017 Tonio Loewald
   }
 
   function snapToTarget(element){
+    if (element == null) {
+      console.warn('carousel cannot snap to target');
+      return;
+    }
+    
     let target = -1;
     const item_list = items();
 
@@ -199,6 +204,7 @@ Copyright ©2016-2017 Tonio Loewald
     }
 
     if (typeof element === 'number') {
+      // shouldn't this also add/remove the carousel-target class?
       element = item_list[element];
     }
 


### PR DESCRIPTION
Can avoid infinite carousel change loops in some cases, depending on what the `carousel-stop` handler does